### PR TITLE
Move Sound Logic to a Separate Module (sounds_utils.py)

### DIFF
--- a/BatteryNotification_MainWindow.py
+++ b/BatteryNotification_MainWindow.py
@@ -32,26 +32,26 @@ TRAY_ICON_EXIST = False
 
 class Ui_MainWindow(QMainWindow):
     global CURRENT_LANGUAGE
-    
 
-        
+
+
     def __init__(self, parent=None):
         super().__init__()
-        
+
         self.setupUi()
         self.setObjectName("MainWindow")
         self.load_file()
         self.translate_app_text()
-        
-        
+
+
         self.battery_information()
-        
-        
-        
-    
+
+
+
+
     def setupUi(self):
         # Отрисовка окна
-        #self.setWindowFlag(Qt.FramelessWindowHint) 
+        #self.setWindowFlag(Qt.FramelessWindowHint)
         #self.setWindowFlag(Qt.Tool)
         #self.setWindowModality(Qt.ApplicationModal)
         self.resize(590, 540)
@@ -65,7 +65,7 @@ class Ui_MainWindow(QMainWindow):
         self.setToolButtonStyle(Qt.ToolButtonIconOnly)
         self.setAnimated(True)
         self.setTabShape(QTabWidget.Rounded)
-        
+
 ################## Отрисовка menuBar######
         #self.menu= QMainWindow.menuBar(self)
 
@@ -76,15 +76,15 @@ class Ui_MainWindow(QMainWindow):
        # loadAction = QAction(QIcon('weather/file.png'), '&Загрузить', self)
        # self.filemenu.addAction(loadAction)
         #loadAction.triggered.connect(self.load_file)
-        
+
         #Ортисовка надписи которая будет исполнять роль статус бара и выводить сообщения
         self.lb_Status_Bar = QLabel(self)
         self.lb_Status_Bar.setAlignment(Qt.AlignLeading|Qt.AlignCenter|Qt.AlignVCenter)
         self.lb_Status_Bar.setGeometry(QRect(10, 510, 565, 35))
         self.lb_Status_Bar.setToolTip("")
         self.lb_Status_Bar.setObjectName("lb_Status_Bar")
-        
-        
+
+
         self.General_Information = QFrame(self)
         self.General_Information.setGeometry(QRect(10, 35, 391, 141))
         self.General_Information.setTabletTracking(False)
@@ -96,7 +96,7 @@ class Ui_MainWindow(QMainWindow):
         self.General_Information.setFrameShape(QFrame.Box)
         self.General_Information.setFrameShadow(QFrame.Raised)
         self.General_Information.setObjectName("General_Information")
-        
+
         self.BatteryBar = QProgressBar(self.General_Information)
         self.BatteryBar.setEnabled(True)
         self.BatteryBar.setGeometry(QRect(10, 10, 61, 121))
@@ -109,16 +109,16 @@ class Ui_MainWindow(QMainWindow):
         self.BatteryBar.setLayoutDirection(Qt.LeftToRight)
         self.BatteryBar.setStyleSheet("")
         self.BatteryBar.setMaximum(100)
-        
-        
-       
+
+
+
         self.BatteryBar.setAlignment(Qt.AlignJustify|Qt.AlignTop)
         self.BatteryBar.setTextVisible(False)
         self.BatteryBar.setOrientation(Qt.Vertical)
         self.BatteryBar.setInvertedAppearance(False)
         self.BatteryBar.setTextDirection(QProgressBar.BottomToTop)
         self.BatteryBar.setObjectName("BatteryBar")
-        
+
         self.layoutWidget = QWidget(self.General_Information)
         self.layoutWidget.setGeometry(QRect(80, 10, 300, 121))
         self.layoutWidget.setToolTip("")
@@ -128,7 +128,7 @@ class Ui_MainWindow(QMainWindow):
         self.formLayout.setHorizontalSpacing(10)
         self.formLayout.setVerticalSpacing(15)
         self.formLayout.setObjectName("formLayout")
-        
+
         self.lb_Percent = QLabel(self.layoutWidget)
         font = QFont()
         font.setPointSize(18)
@@ -138,7 +138,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Percent.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
         self.lb_Percent.setObjectName("lb_Percent")
         self.formLayout.setWidget(0, QFormLayout.LabelRole, self.lb_Percent)
-        
+
         self.lb_Percent_value = QLabel(self.layoutWidget)
         font = QFont()
         font.setPointSize(18)
@@ -150,7 +150,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Percent_value.setObjectName("lb_Percent_value")
         #self.lb_Percent_value.setText(f'{BATTERY_PROPERTIES.percent} %')
         self.formLayout.setWidget(0, QFormLayout.FieldRole, self.lb_Percent_value)
-        
+
         self.lb_Power = QLabel(self.layoutWidget)
         font = QFont()
         font.setPointSize(18)
@@ -164,7 +164,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Power.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
         self.lb_Power.setObjectName("lb_Power")
         self.formLayout.setWidget(1, QFormLayout.LabelRole, self.lb_Power)
-        
+
         self.lb_Power_value = QLabel(self.layoutWidget)
         font = QFont()
         font.setPointSize(18)
@@ -179,7 +179,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Power_value.setAlignment(Qt.AlignRight|Qt.AlignTrailing|Qt.AlignVCenter)
         self.lb_Power_value.setObjectName("lb_Power_value")
         self.formLayout.setWidget(1, QFormLayout.FieldRole, self.lb_Power_value)
-        
+
         self.lb_Left_Sec = QLabel(self.layoutWidget)
         font = QFont()
         font.setPointSize(18)
@@ -193,7 +193,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Left_Sec.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
         self.lb_Left_Sec.setObjectName("lb_Left_Sec")
         self.formLayout.setWidget(2, QFormLayout.LabelRole, self.lb_Left_Sec)
-        
+
         self.lb_Left_Sec_value = QLabel(self.layoutWidget)
         font = QFont()
         font.setPointSize(18)
@@ -205,18 +205,18 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Left_Sec_value.setAccessibleName("")
         self.lb_Left_Sec_value.setAccessibleDescription("")
         self.lb_Left_Sec_value.setScaledContents(False)
-        
+
         self.lb_Left_Sec_value.setAlignment(Qt.AlignRight|Qt.AlignTrailing|Qt.AlignVCenter)
         self.lb_Left_Sec_value.setObjectName("lb_Left_Sec_value")
         self.formLayout.setWidget(2, QFormLayout.FieldRole, self.lb_Left_Sec_value)
-        
+
         self.Setting_Frame = QFrame(self)
         self.Setting_Frame.setGeometry(QRect(410, 35, 170, 141))
         self.Setting_Frame.setToolTip("")
         self.Setting_Frame.setFrameShape(QFrame.Box)
         self.Setting_Frame.setFrameShadow(QFrame.Raised)
         self.Setting_Frame.setObjectName("frame_3")
-        
+
         self.bt_Help = QPushButton(self.Setting_Frame)
         self.bt_Help.setGeometry(QRect(5, 100, 160, 31))
         font = QFont()
@@ -237,7 +237,7 @@ class Ui_MainWindow(QMainWindow):
         self.bt_Settings.setToolTip("")
         self.bt_Settings.setObjectName("bt_Settings")
         self.bt_Settings.clicked.connect(self.show_settings_window)
-        
+
         self.cmb_Languages = QComboBox(self.Setting_Frame)
         self.cmb_Languages.setGeometry(QRect(5, 20, 160, 31))
         font = QFont()
@@ -248,8 +248,8 @@ class Ui_MainWindow(QMainWindow):
         self.cmb_Languages.addItems(["Українська", "English", "Русский"])
         self.cmb_Languages.setObjectName("cmb_Languages")
         self.cmb_Languages.currentIndexChanged.connect(self.language_text)
-        
-        
+
+
 
         ##translate_app_text
         self.lb_Language = QLabel(self.Setting_Frame)
@@ -262,8 +262,8 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Language.setToolTip("")
         self.lb_Language.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
         self.lb_Language.setObjectName("lb_Language")
-        
-        
+
+
         # Отрисовка кнопки "Добавить" или "+"
         #tool_tip_translate = self.translate_app_text(5)
         self.bt_Add_Notification = QPushButton(self)
@@ -280,10 +280,10 @@ class Ui_MainWindow(QMainWindow):
         self.bt_Add_Notification.setObjectName("bt_Add_Notification")
         self.bt_Add_Notification.clicked.connect(self.resize_scrollAreaWidgetContents)
         #self.bt_Add_Notification.clicked.connect(self.add_notification) # Приязка функции на клик по кнопке
-        
-        
-        
-        
+
+
+
+
         self.lb_Notifications = QLabel(self)
         self.lb_Notifications.setGeometry(QRect(120, 178, 321, 31))
         font = QFont()
@@ -294,7 +294,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Notifications.setToolTip("")
         self.lb_Notifications.setAlignment(Qt.AlignCenter)
         self.lb_Notifications.setObjectName("lb_Notifications")
-        
+
         # Отрисовка ScrollArea
         self.scrollArea = QScrollArea(self)
         self.scrollArea.setGeometry(QRect(10, 210, 570, 305))
@@ -308,14 +308,14 @@ class Ui_MainWindow(QMainWindow):
         #height_scrollAreaWidgetContents = self.resize_scrollAreaWidgetContents()
         ##################
         self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 551, 300)) # Нужно будет прописать функцию которая меняет геометрию в зависимости от количества объектов, минимальное 300, когда больше 3 объектов тогда + высота объекта (90) + 10
-        
+
         self.scrollAreaWidgetContents.setLayoutDirection(Qt.LeftToRight)
         self.scrollAreaWidgetContents.setObjectName("scrollAreaWidgetContents")
         self.verticalLayout = QVBoxLayout(self.scrollAreaWidgetContents)
         self.verticalLayout.setContentsMargins(9, -1, -1, -1)
         self.verticalLayout.setObjectName("verticalLayout")
         self.scrollArea.setWidget(self.scrollAreaWidgetContents)
-        
+
         # Отрисовка кнопки "Save"
         self.bt_Save_Changes = QPushButton(self)
         self.bt_Save_Changes.setGeometry(QRect(10, 3, 100, 30))
@@ -326,21 +326,21 @@ class Ui_MainWindow(QMainWindow):
         font.setWeight(75)
         self.bt_Save_Changes.setFont(font)
         self.bt_Save_Changes.setToolTip("")
-        
+
         self.bt_Save_Changes.setStyleSheet("color:green")
         self.bt_Save_Changes.setObjectName("bt_Save_Changes")
         self.bt_Save_Changes.clicked.connect(self.save) # Приязка функции на клик по кнопке
-        
-        
-        
-    def add_notification(self): 
+
+
+
+    def add_notification(self):
     # Эта функция добавляет в ScrollArea блоки с уведомлениями, здесь идет отрисовка блока и его дочерниз элементов
-        
-        
-        
+
+
+
         global I_COUNT ########### Глобальный счетчик для придания всем блокам и их элементам уникальных имен
-        
-        # Отрисовка самого блока (фрейма) 
+
+        # Отрисовка самого блока (фрейма)
         # Frame внутри которого будут размещатся остальные элементы
         self.Notification = QFrame(self.scrollAreaWidgetContents)
         self.Notification.setMinimumSize(QSize(530, 90))
@@ -350,72 +350,72 @@ class Ui_MainWindow(QMainWindow):
         self.Notification.setFrameShadow(QFrame.Raised)
         Notif = self.Notification # Переменная нужна для ссылки на этот фрейм перед тем как ему присвоится имя объекта
         self.Notification.setObjectName(f"Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
-        #Отрисовка дочерних элементов 
-        
+
+        #Отрисовка дочерних элементов
+
         #Текстовое поле (Line Edit) в которое вводится процент заряда при котором будет выводится уведомления
-        self.tb_Percent_Notification = QLineEdit(Notif) 
+        self.tb_Percent_Notification = QLineEdit(Notif)
         self.tb_Percent_Notification.setGeometry(QRect(5, 20, 41, 31))
         font = QFont()
         font.setPointSize(14)
         self.tb_Percent_Notification.setFont(font)
-        
+
         self.tb_Percent_Notification.setText('0')
         self.tb_Percent_Notification.setMaxLength(3) # Установка максимального количества вводимых символов
         validator = QIntValidator(self) # Ограничитель, в даном случае для ввода допустимы только числа
         self.tb_Percent_Notification.setValidator(validator) # Установка механизма допустимости в нужное поле
         ### Соединить из сохранениям
         #self.tb_Percent_Notification.editingFinished.connect(self.save_file)
-        
+
         self.tb_Percent_Notification.editingFinished.connect(self.edit_percent_notification)
         self.tb_Percent_Notification.textChanged.connect(self.change_percent_notification) ############### Связь из функцией при каждом изменении текста
         self.tb_Percent_Notification.setObjectName(f"tb_Percent_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
+
         #Текстовое поле (Plain Text Edit) в которе текст уведомления котрый будет выводится в окно с уведомлениям
         self.tb_Message_Notification = QPlainTextEdit(Notif)
         self.tb_Message_Notification.setGeometry(QRect(50, 21, 360, 61))
         font = QFont()
         font.setPointSize(12)
         self.tb_Message_Notification.setFont(font)
-        
+
         ### Соединить из сохранениям
         #self.tb_Message_Notification.textChanged.connect(self.edit_message_notification)
-        
+
         #self.tb_Message_Notification.textChanged.connect(FUNCTION) ############### Связь из функцией при каждом изменении текста
         self.tb_Message_Notification.setObjectName(f"tb_Message_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
+
         #CheckBox (True значит что будет выводится окно с уведомлениям, False блокирует эту возможность
         self.chb_Text_Notification = QCheckBox(Notif)
         self.chb_Text_Notification.setGeometry(QRect(420, 20, 111, 21))
         font = QFont()
         font.setPointSize(12)
         self.chb_Text_Notification.setFont(font)
-        
+
         self.chb_Text_Notification.setLayoutDirection(Qt.LeftToRight)
         self.chb_Text_Notification.setChecked(True)
         self.chb_Text_Notification.setObjectName(f"chb_Text_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
-        #CheckBox (True значит что будет осуществлятся звуковое уведомления, False блокирует эту возможность 
+
+        #CheckBox (True значит что будет осуществлятся звуковое уведомления, False блокирует эту возможность
         self.chb_Sound_Notification = QCheckBox(Notif)
         self.chb_Sound_Notification.setGeometry(QRect(420, 40, 111, 21))
         font = QFont()
         font.setPointSize(12)
         self.chb_Sound_Notification.setFont(font)
-        
+
         self.chb_Sound_Notification.setLayoutDirection(Qt.LeftToRight)
         self.chb_Sound_Notification.setChecked(False)
         self.chb_Sound_Notification.stateChanged.connect(self.sound_check)
         self.chb_Sound_Notification.setObjectName(f"chb_Sound_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
+
         #ComboBox со списком доступных звуков уведомлений (при значении chb_Sound_Notification - False список перестает быть активным)
         self.cmb_Sounds_Notification = QComboBox(Notif)
         self.cmb_Sounds_Notification.setGeometry(QRect(420, 60, 111, 22))
         self.cmb_Sounds_Notification.setEnabled(False)
         self.cmb_Sounds_Notification.setSizeAdjustPolicy(self.cmb_Sounds_Notification.AdjustToMinimumContentsLength)
-        
-        
-        
-        
+
+
+
+
         font = QFont()
         font.setPointSize(10)
         #self.cmb_Sounds_Notification.setModel(sounds_model)
@@ -425,7 +425,7 @@ class Ui_MainWindow(QMainWindow):
         #self.cmb_Sounds_Notification.currentIndexChanged.connect(self.save_file)
         #self.cmb_Sounds_Notification.currentIndexChanged.connect(FUNCTION) ########## ############### Связь из функцией при каждом изменении выбранного элемента
         self.cmb_Sounds_Notification.setObjectName(f"cmb_Sounds_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        # Добавление элементов в комбобокс 
+        # Добавление элементов в комбобокс
         sounds = os.listdir(r"Sounds")
         for x in sounds:
             if x[-4:] == '.wav':
@@ -433,7 +433,7 @@ class Ui_MainWindow(QMainWindow):
         #self.cmb_Sounds_Notification.addItem("")
         #self.cmb_Sounds_Notification.addItem("")
         #self.cmb_Sounds_Notification.addItem("")
-        
+
         #Label надпись "Процент"
         self.lb_Percent_Notification = QLabel(Notif)
         self.lb_Percent_Notification.setGeometry(QRect(5, 3, 71, 15))
@@ -446,7 +446,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Percent_Notification.setToolTip("")
         self.lb_Percent_Notification.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
         self.lb_Percent_Notification.setObjectName(f"lb_Percent_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
+
         #Label надпись "Сообщение"
         self.lb_Message_Notification = QLabel(self.Notification)
         self.lb_Message_Notification.setGeometry(QRect(180, 3, 151, 15))
@@ -459,7 +459,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Message_Notification.setToolTip("")
         self.lb_Message_Notification.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
         self.lb_Message_Notification.setObjectName(f"lb_Message_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
+
         #Label надпись "Тип уведомления"
         self.lb_Type_Notification = QLabel(Notif)
         self.lb_Type_Notification.setGeometry(QRect(420, 3, 151, 15))
@@ -472,7 +472,7 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Type_Notification.setToolTip("")
         self.lb_Type_Notification.setAlignment(Qt.AlignLeading|Qt.AlignLeft|Qt.AlignVCenter)
         self.lb_Type_Notification.setObjectName(f"lb_Type_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
+
         #PushButton который удаляет блок с уведомлением
         self.bt_Del_Notification = QPushButton(Notif)
         self.bt_Del_Notification.setGeometry(QRect(5, 55, 30, 30))
@@ -481,192 +481,182 @@ class Ui_MainWindow(QMainWindow):
         font.setPointSize(16)
         font.setBold(True)
         self.bt_Del_Notification.setFont(font)
-        
+
         self.bt_Del_Notification.setText("–")
         self.bt_Del_Notification.setStyleSheet("color:red\n""")
         self.bt_Del_Notification.clicked.connect(self.resize_scrollAreaWidgetContents)
         #self.bt_Del_Notification.clicked.connect(self.del_notification) # Привязка функции на клик по кнопке
         self.bt_Del_Notification.setObjectName(f"bt_Del_Notification_{I_COUNT}") # Присваивание уникального имени объекта
-        
-        
-        self.verticalLayout.addWidget(Notif) # Добавление в вертикальную сетку ScrollArea блока с уведомлениям 
-        
+
+
+        self.verticalLayout.addWidget(Notif) # Добавление в вертикальную сетку ScrollArea блока с уведомлениям
+
         I_COUNT += 1 ###################  Добавления к счетчику 1, чтобы в будующем всем блокам и дочерним объектам присваивались уникальные имена
         self.translate_app_text()
-        
-        
-    
+
+
+
     def del_notification(self):
     # Активируется при нажатии на bt_Del_Notification и удаляет родительский блок с уведомлениям
-         
+
         button = self.sender() # Определяет источник сигнала
         parrent_object = button.parentWidget() # Опредления родительского объекта
         parrent_object.deleteLater() # Удаляет родительский объект
-        
+
         #self.lb_Status_Bar.setStyleSheet("QLabel {color: green;}")
-        
+
     def save (self):
         self.save_file(1)
-        
+
     def save_file(self, set=1):
         ### Смысл функции сохранения следующий, определяется список всех дочерных объектов в ScrollArea, в них определяются блоки с уведомлениями которые добавил пользователь
         # эти блоки нужно сохранить, чтобы когда пользователь вновь откроет программу в ней были все добавлены им уведомления
         # программа идентифицирует все блоки, которые есть в ScrollArea и добавит подсписок блока список Notification_list, после идентифицируются дочерные элементы (блок затем дочерные элементы)
         # у некоторых дочерних элементов есть параметры которые нужно сохранить, они и будут добавлены в подсписок к материнскому блоку (фрейму)
         # после этого итоговый список Notification_list будет сохранен в файл. Конец функции
-        
+
         if set == 1:
             Notification_list = [] #итоговый список параметров всех блоков
-            
-        
+
+
             settings = QSettings(CONFIG_FILE_NAME, QSettings.IniFormat)
             settings.setValue("Notification_list",Notification_list.copy())
             Notification_list = self.detect_notification()
-            
+
             settings.setValue("Notification_list", Notification_list.copy())
-            
+
             # сохранения комбобокса с языками
-            mo = self.cmb_Languages.metaObject() 
+            mo = self.cmb_Languages.metaObject()
             for k in range(mo.propertyCount()):  # пробегает по всех параметрах текущего объекта (combobox со списком доступнх звуков для уведомления)
                 name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                if name == 'currentText': 
+                if name == 'currentText':
                     settings.setValue("Language",("{}/{}".format(self.cmb_Languages.objectName(), name), self.cmb_Languages.property(name)))
-            
+
             message_translate = self.translate_app_text(2)
             self.status_bar_message(message_translate[0])
         if set == 2:
             settings = QSettings(CONFIG_FILE_NAME, QSettings.IniFormat)
-            mo = self.cmb_Languages.metaObject() 
+            mo = self.cmb_Languages.metaObject()
             for k in range(mo.propertyCount()):  # пробегает по всех параметрах текущего объекта (combobox со списком доступнх звуков для уведомления)
                 name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                if name == 'currentText': 
+                if name == 'currentText':
                     settings.setValue("Language",("{}/{}".format(self.cmb_Languages.objectName(), name), self.cmb_Languages.property(name)))
-            
-            
-             #Для очистки файла, он перезапишется в конце функции
-            
-        
-        
-        
 
-        
+
+             #Для очистки файла, он перезапишется в конце функции
+
+
+
+
+
+
         #Список всех дочерных объектов в ScrollArea, нужно для того, чтобы определить фреймы (блоки) уведомлений
-    
-    
+
+
     def detect_notification(self):
         global I_COUNT #Счетчик блоков (фреймов) с уведомлениями
         Notification_list = [] #итоговый список параметров всех блоков
-        
+
         name_Notification = '' #имя блока, нужно для идентификации дочерних элементов каждого блока
         child_list = self.scrollArea.findChildren(QObject)
-            
-            
+
+
             # Цикл проходится по всем дочерним элементам
         for x in child_list:
-            
+
                 mo = x.metaObject() #Переменная нужна, чтобы записать параметры объекта - (mo.property())
-                
+
                 # Проверка имени объекта, идентифицируем блок с уведомлением - (Notification_X: type(QFrame))
                 # Сначала будет определен блок с уведомлениями, а затем его дочерние элементы, и так прогонится каждый блок уведомлений
-                
+
                 #Идентификация среди списка дочерних объектов ScrollArea блоков (frame) уведомлений
-                if len('Notification_ ') == len(x.objectName()) and 'Notification_' in x.objectName() or len('Notification_  ') == len(x.objectName()) and 'Notification_' in x.objectName(): 
+                if len('Notification_ ') == len(x.objectName()) and 'Notification_' in x.objectName() or len('Notification_  ') == len(x.objectName()) and 'Notification_' in x.objectName():
                         Notification_list.append([x.objectName()])# добавляем в список параметров подсписок с блоком уведомлений
                         name_Notification = x.objectName() # имя блока уведомлений, нужен для идентификации его дочерних элементов (следующие if)
                         num_in_Notification_list = Notification_list.index(Notification_list[-1]) # возвращает индекс подспика блока уведомлений в общем списке параметров, нужен чтобы добавить в него параметры дочерних элементов
                         #print(f'num_in_Notification_list {num_in_Notification_list}')
-                     
+
                 if f'tb_Percent_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea текстового поля со значениям заряда батареи
                         for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (текстовое поле заряд батареи)
                             name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                             if name == 'text': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
                                 Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name))) # Добавляет значения текста поля заряда батареи в подсписок текущего блока уведомлений
-                
+
                 if f'tb_Message_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea текстового поля со значениям текста уведомления
                         for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (текстовое поле текст уведомления)
                             name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                             if name == 'plainText': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
                                 Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name))) # Добавляет значения текста поля уведомления в подсписок текущего блока уведомлений
-                
+
                 if f'chb_Text_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea checkbox который определяет вызов окна уведомления из сообщениям
                         for k in range(mo.propertyCount()):  # пробегает по всех параметрах текущего объекта (checkbox который определяет вызов окна уведомления из сообщениям)
                             name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                             if name == 'checked': # Проверка на нужное имя параметра, конкретно этот параметр возвращает значения checkbox выбраного пользователем
                                 Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name)))   # Добавляет значения чекбокса текстового окна в подсписок текущего блока уведомлений
-                
+
                 if f'chb_Sound_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea checkbox который определяет вызов звукового уведомления
                         for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (checkbox который определяет вызов звукового уведомления)
                             name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                             if name == 'checked': # Проверка на нужное имя параметра, конкретно этот параметр возвращает значения checkbox выбраного пользователем
-                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name)))  # Добавляет значения чекбокса звукового уведомления в подсписок текущего блока уведомлений         
-                
+                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name)))  # Добавляет значения чекбокса звукового уведомления в подсписок текущего блока уведомлений
+
                 if f'cmb_Sounds_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea combobox со списком доступнх звуков для уведомления
                         for k in range(mo.propertyCount()):  # пробегает по всех параметрах текущего объекта (combobox со списком доступнх звуков для уведомления)
                             name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                             if name == 'currentText': # Проверка на нужное имя параметра, конкретно этот параметр возвращает значения выбранного элемента в combobox
-                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name))) # Добавляет значения combobox со списком доступнх звуков  в подсписок текущего блока уведомлений      
+                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name))) # Добавляет значения combobox со списком доступнх звуков  в подсписок текущего блока уведомлений
             #print (Notification_list)
             #print(f'LEN ISv{len(child_list)}')
         return Notification_list
-            
+
             #print(settings.value("Notification_list")) # Просмотр формата вывода параметров
-                
 
+    def load_file(self):
+        if not os.path.exists(CONFIG_FILE_NAME) or os.path.getsize(CONFIG_FILE_NAME) == 0:
+            with open(CONFIG_FILE_NAME, 'w', encoding='utf-8') as f:
+                pass
+            self.lb_Status_Bar.setText("Config file was missing or empty. A new file was created.")
+            self.lb_Status_Bar.setStyleSheet("QLabel {color: red;}")
 
-
-
-
-
-
-
-    def load_file(self): # Функция загрузки, запускается автоматически в конструкторе __init__
-        
         global I_COUNT
-        
-        settings = QSettings(CONFIG_FILE_NAME, QSettings.IniFormat) 
-        
-        #Дописать сюда загрузку значения комбобокса с языками
+        settings = QSettings(CONFIG_FILE_NAME, QSettings.IniFormat)
+
         Language_property = settings.value("Language")
-        if Language_property is None: # Возвращает 0 если файл пустой
+        if Language_property is None:
             return 0
         if Language_property:
             self.cmb_Languages.setCurrentText(Language_property[1])
-            
-        #Достает из файла значения со списком блоков уведомлений и восстанавливает их в окне
-        Load_Notification_list = settings.value("Notification_list") # Возвращает список с блоками уведомлений и их параметрами из файла
-        if Load_Notification_list is None: # Возвращает 0 если файл пустой
+
+        Load_Notification_list = settings.value("Notification_list")
+        if Load_Notification_list is None:
             return 0
-        
+
         if Load_Notification_list:
-            for notification in Load_Notification_list: # Проход по всех подсписках с блоками (каждый подсписок соотвествует блоку уведомлений)
-                
-                I_COUNT = Load_Notification_list.index(notification) # Присвивает глобальному счетчику значения индекса подсписка с блоком уведомлений, счетчик нужен для функции добавления блоков, благодаря ему именуются эти блоки
-                self.add_notification() #Запускает функцию добавления элемента
-                # Текстовое поле с зарядом батареии
-                Percent_Notification = notification[1] # Присваивает индекс кортежа с именем объекта и её параметром
-                tb_Percent_Notification_TEXT = Percent_Notification[1] # Присвоение переменной значения параметра
-                self.tb_Percent_Notification.setText(tb_Percent_Notification_TEXT) # Присвоение объекту значения параметра переданого из файла с сохранением
-                # Текстовое поле с сообщениям для уведомления
-                Message_Notification = notification[2] # Присваивает индекс кортежа с именем объекта и её параметром
-                tb_Message_Notification_TEXT = Message_Notification[1] # Присвоение переменной значения параметра
-                self.tb_Message_Notification.setPlainText(tb_Message_Notification_TEXT) # Присвоение объекту значения параметра переданого из файла с сохранением
-                # Checkbox для определения нужды в  выводе окна с сообщениям
-                Text_Notification = notification[3] # Присваивает индекс кортежа с именем объекта и её параметром
-                chb_Text_Notification_CHECKED = bool(Text_Notification[1]) # Присвоение переменной значения параметра
-                self.chb_Text_Notification.setChecked(chb_Text_Notification_CHECKED) # Присвоение объекту значения параметра переданого из файла с сохранением
-                # Checkbox для определения нужды в звуковом уведолмении
-                Sound_Notification = notification[4] # Присваивает индекс кортежа с именем объекта и её параметром
-                chb_Sound_Notification_CHECKED = bool(Sound_Notification[1]) # Присвоение переменной значения параметра
-                self.chb_Sound_Notification.setChecked(chb_Sound_Notification_CHECKED) # Присвоение объекту значения параметра переданого из файла с сохранением
-                # ComboBox со списком доступных звуков
-                Sounds_Notification = notification[5] # Присваивает индекс кортежа с именем объекта и её параметром
-                cmb_Sounds_Notification_CURRENT_TEXT = Sounds_Notification[1] # Присвоение переменной значения параметра
-                self.cmb_Sounds_Notification.setCurrentText(cmb_Sounds_Notification_CURRENT_TEXT) # Присвоение объекту значения параметра переданого из файла с сохранением
-            
-        self.resize_scrollAreaWidgetContents()        
-                
-                
-           
+            for notification in Load_Notification_list:
+                I_COUNT = Load_Notification_list.index(notification)
+                self.add_notification()
+
+                Percent_Notification = notification[1]
+                tb_Percent_Notification_TEXT = Percent_Notification[1]
+                self.tb_Percent_Notification.setText(tb_Percent_Notification_TEXT)
+
+                Message_Notification = notification[2]
+                tb_Message_Notification_TEXT = Message_Notification[1]
+                self.tb_Message_Notification.setPlainText(tb_Message_Notification_TEXT)
+
+                Text_Notification = notification[3]
+                chb_Text_Notification_CHECKED = bool(Text_Notification[1])
+                self.chb_Text_Notification.setChecked(chb_Text_Notification_CHECKED)
+
+                Sound_Notification = notification[4]
+                chb_Sound_Notification_CHECKED = bool(Sound_Notification[1])
+                self.chb_Sound_Notification.setChecked(chb_Sound_Notification_CHECKED)
+
+                Sounds_Notification = notification[5]
+                cmb_Sounds_Notification_CURRENT_TEXT = Sounds_Notification[1]
+                self.cmb_Sounds_Notification.setCurrentText(cmb_Sounds_Notification_CURRENT_TEXT)
+
+        self.resize_scrollAreaWidgetContents()
 
     def edit_percent_notification(self):
         percent_sender = self.sender()
@@ -680,32 +670,32 @@ class Ui_MainWindow(QMainWindow):
             msg.setWindowTitle(msg_translate[1])
             retval = msg.exec_()
             percent_sender.setText('0')
-            
+
         else: percent_sender.setText(str(int(Percent_Notification)))
-    
-    
+
+
     def change_percent_notification(self):
         percent_sender = self.sender()
         Percent_Notification = percent_sender.text()
         if not Percent_Notification.isalnum():
             percent_sender.setText('0')
-        
-        
-            
+
+
+
     def resize_scrollAreaWidgetContents(self):
         global I_COUNT
         button_sender = self.sender()
         #Notification_list = self.detect_notification()
-        
+
         if I_COUNT == 0:
             self.height_scrollAreaWidgetContents = 0
-            
-        if button_sender is None: 
+
+        if button_sender is None:
             self.height_scrollAreaWidgetContents = I_COUNT * 100
             self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 551, self.height_scrollAreaWidgetContents))
             return self.height_scrollAreaWidgetContents
-            
-            
+
+
         if 'bt_Add_Notification' in button_sender.objectName():
             Notification_list = self.detect_notification()
             self.height_scrollAreaWidgetContents = self.height_scrollAreaWidgetContents + 100
@@ -714,7 +704,7 @@ class Ui_MainWindow(QMainWindow):
             #Notification_list = self.detect_notification()
             message_translate = self.translate_app_text(2)
             self.status_bar_message(message_translate[1])###############################################TRANSLATE
-            
+
         if 'bt_Del_Notification' in button_sender.objectName():
             Notification_list = self.detect_notification()
             self.height_scrollAreaWidgetContents = self.height_scrollAreaWidgetContents - 100
@@ -723,23 +713,23 @@ class Ui_MainWindow(QMainWindow):
             #Notification_list = self.detect_notification()
             message_translate = self.translate_app_text(2)
             self.status_bar_message(message_translate[2]) ###############################################TRANSLATE
-            
-        
+
+
         return self.height_scrollAreaWidgetContents
-        
-     
+
+
     def sound_check(self):
         checkbox = self.sender()
         notification_frame = checkbox.parentWidget ()
         cmb_child = notification_frame.findChildren(QComboBox)
         cmb_sound = cmb_child[0]
-        
+
         if checkbox.isChecked():
             cmb_sound.setEnabled(True)
         if not checkbox.isChecked():
             cmb_sound.setEnabled(False)
-            
-    
+
+
     def status_bar_message (self, message = ''):
         font = QFont()
         font.setFamily("Times New Roman")
@@ -750,10 +740,10 @@ class Ui_MainWindow(QMainWindow):
         self.lb_Status_Bar.setFont(font)
         self.lb_Status_Bar.setText(message) ###############################################TRANSLATE
         self.lb_Status_Bar.setStyleSheet("QLabel {color: green;}")
-        self.timer = QTimer() # 
+        self.timer = QTimer() #
         self.timer.start(5000) #
         self.timer.timeout.connect(self.clear_message) #
-        
+
     def clear_message (self):
         self.lb_Status_Bar.setText('')
         self.timer = QTimer() #
@@ -761,10 +751,10 @@ class Ui_MainWindow(QMainWindow):
 
     def translate_app_text(self, set=1):
         Notification_list = self.detect_notification()
-        
+
         # Translate UI MainWindow
         if set == 1:
-            
+
             if self.cmb_Languages.currentText() == 'Українська':
                 self.setWindowTitle("Notebook / Laptop Battery Notification")
                 self.lb_Percent.setText("Заряд:")
@@ -782,8 +772,8 @@ class Ui_MainWindow(QMainWindow):
                 chb_text_notification_text = 'Текст'
                 chb_sound_notification_text = 'Звук'
                 self.bt_Add_Notification.setToolTip('Натисніть на кнопку, щоб додати нове сповіщення')
-                
-            if self.cmb_Languages.currentText() == 'Русский':    
+
+            if self.cmb_Languages.currentText() == 'Русский':
                 self.setWindowTitle("Notebook / Laptop Battery Notification")
                 self.lb_Percent.setText("Заряд:")
                 self.lb_Power.setText("Питание:")
@@ -800,8 +790,8 @@ class Ui_MainWindow(QMainWindow):
                 chb_text_notification_text = 'Текст'
                 chb_sound_notification_text = 'Звук'
                 self.bt_Add_Notification.setToolTip('Нажмите на данную кнопку, чтобы добавить новое уведомление')
-                
-            if self.cmb_Languages.currentText() == 'English':    
+
+            if self.cmb_Languages.currentText() == 'English':
                 self.setWindowTitle("Notebook / Laptop Battery Notification")
                 self.lb_Percent.setText("Level:")
                 self.lb_Power.setText("Power:")
@@ -818,65 +808,65 @@ class Ui_MainWindow(QMainWindow):
                 chb_text_notification_text = 'Text'
                 chb_sound_notification_text = 'Sound'
                 self.bt_Add_Notification.setToolTip('Click on this button for add new notification')
-                
-                
-            
+
+
+
             name_Notification = '' #имя блока, нужно для идентификации дочерних элементов каждого блока
             child_list = self.scrollArea.findChildren(QObject)
             tool_tip_translate = self.translate_app_text(5)
             # Цикл проходится по всем дочерним элементам
             for x in child_list:
-            
+
                 if len('Notification_ ') == len(x.objectName()) and 'Notification_' in x.objectName() or len('Notification_  ') == len(x.objectName()) and 'Notification_' in x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea блоков (frame) уведомлений
                         name_Notification = x.objectName() # имя блока уведомлений, нужен для идентификации его дочерних элементов (следующие if)
-                
-                if f'lb_Message_{name_Notification}' == x.objectName(): 
+
+                if f'lb_Message_{name_Notification}' == x.objectName():
                         x.setText(message_notification_text)
-                
-                if f'tb_Message_{name_Notification}' == x.objectName(): 
+
+                if f'tb_Message_{name_Notification}' == x.objectName():
                         x.setToolTip(tool_tip_translate[1])
-                
-                if f'lb_Percent_{name_Notification}' == x.objectName(): 
+
+                if f'lb_Percent_{name_Notification}' == x.objectName():
                         x.setText(percent_notification_text)
-                
-                if f'tb_Percent_{name_Notification}' == x.objectName(): 
+
+                if f'tb_Percent_{name_Notification}' == x.objectName():
                         x.setToolTip(tool_tip_translate[2])
-                
-                if f'lb_Type_{name_Notification}' == x.objectName(): 
+
+                if f'lb_Type_{name_Notification}' == x.objectName():
                         x.setText(type_notification_text)
-                        
-                
-                if f'chb_Text_{name_Notification}' == x.objectName(): 
+
+
+                if f'chb_Text_{name_Notification}' == x.objectName():
                         x.setText(chb_text_notification_text)
                         x.setToolTip(tool_tip_translate[4])
-                
-                if f'chb_Sound_{name_Notification}' == x.objectName(): 
+
+                if f'chb_Sound_{name_Notification}' == x.objectName():
                         x.setText(chb_sound_notification_text)
                         x.setToolTip(tool_tip_translate[3])
-                if f'bt_Del_{name_Notification}' == x.objectName(): 
+                if f'bt_Del_{name_Notification}' == x.objectName():
                         x.setToolTip(tool_tip_translate[0])
-             
-        
+
+
         # Translate status bar
-        if set == 2:   
+        if set == 2:
             if self.cmb_Languages.currentText() == 'Українська':
                 save_message = ('Зміни успішно збережено')
                 add_notification_message = (f'Сповіщення успішно додано, всього: {len(Notification_list)}')
                 del_notification_message = (f'Сповіщення видалено, всього залишилось: {len(Notification_list)-1}')
                 return save_message, add_notification_message, del_notification_message
-            
-            if self.cmb_Languages.currentText() == 'Русский': 
+
+            if self.cmb_Languages.currentText() == 'Русский':
                 save_message = ('Изменения успешно сохранены')
                 add_notification_message = (f'Уведомление успешно добавлено, всего: {len(Notification_list)}')
                 del_notification_message = (f'Уведомление успешно удалено, всего: {len(Notification_list)-1}')
                 return save_message, add_notification_message, del_notification_message
-            
-            if self.cmb_Languages.currentText() == 'English': 
+
+            if self.cmb_Languages.currentText() == 'English':
                 save_message = ('Ghanges has been saved')
                 add_notification_message = (f'Notification succesfully added, count: {len(Notification_list)}')
                 del_notification_message = (f'Notification succesfully deleted, count: {len(Notification_list)-1}')
                 return save_message, add_notification_message, del_notification_message
-        
+
         # translate Battery information
         if set == 3:
             if self.cmb_Languages.currentText() == 'Українська':
@@ -887,8 +877,8 @@ class Ui_MainWindow(QMainWindow):
                 сharging_text = 'Заряджається '
                 unknown_сharging_text = 'Не визначено '
                 message_notification_Title = 'Сповіщення'
-            
-            if self.cmb_Languages.currentText() == 'Русский': 
+
+            if self.cmb_Languages.currentText() == 'Русский':
                 plugged_text = 'Подключено '
                 unplugged_text = 'Не подключено '
                 unknown_plugged_text = 'Не определено '
@@ -896,8 +886,8 @@ class Ui_MainWindow(QMainWindow):
                 сharging_text = 'Заряжается '
                 unknown_сharging_text = 'Не определено '
                 message_notification_Title = 'Уведомление'
-            
-            if self.cmb_Languages.currentText() == 'English':   
+
+            if self.cmb_Languages.currentText() == 'English':
                 plugged_text = 'Plugged '
                 unplugged_text = 'Unplugged '
                 unknown_plugged_text = 'Undefined '
@@ -906,7 +896,7 @@ class Ui_MainWindow(QMainWindow):
                 unknown_сharging_text = 'Undefined '
                 message_notification_Title = 'Notification'
             return plugged_text, unplugged_text, unknown_plugged_text, determing_text, сharging_text, unknown_сharging_text, message_notification_Title
-        
+
         # Translate exit maessagebox
         if set == 4:
             if self.cmb_Languages.currentText() == 'Українська':
@@ -915,22 +905,22 @@ class Ui_MainWindow(QMainWindow):
                 button_No_text = 'Ні'
                 button_Tray_text = 'Згорнути у трей'
                 exit_message_Title = 'Вихід'
-            
+
             if self.cmb_Languages.currentText() == 'Русский':
                 exit_message_text = 'Все несохраненные данные будут потеряны, Вы уверены, что хотите закрыть программу?'
                 button_Yes_text = 'Да'
                 button_No_text = 'Нет'
                 button_Tray_text = 'Свернуть в трей'
                 exit_message_Title = 'Выход'
-            
-            if self.cmb_Languages.currentText() == 'English': 
+
+            if self.cmb_Languages.currentText() == 'English':
                 exit_message_text = 'All unsaved data will be lost. Are you sure you want to close the application?'
                 button_Yes_text = 'Yes'
                 button_No_text = 'No'
                 button_Tray_text = 'Minimize to tray'
                 exit_message_Title = 'Exit'
             return exit_message_text, button_Yes_text, button_No_text, button_Tray_text, exit_message_Title
-        
+
         # Translate Tool Tips
         if set == 5:
             if self.cmb_Languages.currentText() == 'Українська':
@@ -940,7 +930,7 @@ class Ui_MainWindow(QMainWindow):
                 ToolTip_tb_Percent_Notification = 'Запишіть сюди заряд батареї, при якому сповіщення буде показано'
                 ToolTip_chb_Sound_Notification = 'Натисніть на цей прапірець, якщо хочете ввімкнути / вимкнути звукові сповіщення'
                 ToolTip_chb_Text_Notification = 'Натисніть на цей прапірець, якщо хочете ввімкнути / вимкнути текстові сповіщення'
-                
+
             if self.cmb_Languages.currentText() == 'Русский':
                 #ToolTip_bt_Add_Notification = 'Нажмите на данную кнопку, чтобы добавить новое уведомление'
                 ToolTip_bt_Del_Notification = 'Нажмите на данную кнопку, чтобы удалить текущее уведомление'
@@ -948,21 +938,21 @@ class Ui_MainWindow(QMainWindow):
                 ToolTip_tb_Percent_Notification = 'Запишите сюда заряд батареи при котором, уведомления будет показано'
                 ToolTip_chb_Sound_Notification = 'Нажмите на этот флажок, если хотите включить / выключить звуковые уведомления'
                 ToolTip_chb_Text_Notification = 'Нажмите на этот флажок, если хотите включить / выключить текстовые уведомления'
-            
-            if self.cmb_Languages.currentText() == 'English': 
+
+            if self.cmb_Languages.currentText() == 'English':
                 #ToolTip_bt_Add_Notification = 'Click on this button for add new notification'
-                
+
                 ToolTip_bt_Del_Notification = 'Click on this button for delete this notification'
                 ToolTip_tb_Message_Notification = 'Write down your notification message'
                 ToolTip_tb_Percent_Notification = 'Write down percent battery when notification will be show'
                 ToolTip_chb_Sound_Notification = 'Click on this checkbox if you wanna turn on / turn off sound notification'
                 ToolTip_chb_Text_Notification = 'Click on this checkbox if you wanna turn on / turn off text notification'
-            
+
             return ToolTip_bt_Del_Notification, ToolTip_tb_Message_Notification, ToolTip_tb_Percent_Notification, ToolTip_chb_Sound_Notification, ToolTip_chb_Text_Notification
-        
+
         # Tray ContextMenu
         if set == 6:
-        
+
             if self.cmb_Languages.currentText() == 'Українська':
                 show_action_text = "Показати"
                 settings_action_text = "Налаштування"
@@ -971,7 +961,7 @@ class Ui_MainWindow(QMainWindow):
                 hide_action_text = "Приховати"
                 showMessage_Title = 'Notebook / Laptop Battery Notification'
                 showMessage_text = 'Програма була згорнута до системного трею'
-                
+
             if self.cmb_Languages.currentText() == 'Русский':
                 show_action_text = "Показать"
                 settings_action_text = "Настройки"
@@ -980,8 +970,8 @@ class Ui_MainWindow(QMainWindow):
                 hide_action_text = "Скрыть"
                 showMessage_Title = 'Notebook / Laptop Battery Notification'
                 showMessage_text = 'Программа была свернута в системный трей'
-                
-            if self.cmb_Languages.currentText() == 'English': 
+
+            if self.cmb_Languages.currentText() == 'English':
                 show_action_text = "Show"
                 settings_action_text = "Settings"
                 help_action_text = "Help"
@@ -989,26 +979,26 @@ class Ui_MainWindow(QMainWindow):
                 hide_action_text = "Hide"
                 showMessage_Title = 'Notebook / Laptop Battery Notification'
                 showMessage_text = 'Application was minimized to Tray'
-            
+
             return show_action_text, settings_action_text, help_action_text, quit_action_text, hide_action_text, showMessage_Title, showMessage_text
-        
+
         # Greater percent
         if set == 7:
-        
+
             if self.cmb_Languages.currentText() == 'Українська':
                 message = 'Введене число більше 100, будь-ласка введіть число в діапазоні від 0 до 100!'
                 title = 'Попередження!'
-                
+
             if self.cmb_Languages.currentText() == 'Русский':
                 message = 'Введенное число больше 100, пожалуйста введите число в диапазоне от 0 до 100!'
                 title = ''
-                
-            if self.cmb_Languages.currentText() == 'English': 
+
+            if self.cmb_Languages.currentText() == 'English':
                 message = 'The entered number is greater than 100, please enter a number between 0 and 100'
                 title = 'Warning'
-                
-            return message, title   
-                
+
+            return message, title
+
 ###########################MESSAGEBOX#########################################
             #msg = QMessageBox(self)
             #msg.setIcon(QMessageBox.Information)
@@ -1020,15 +1010,15 @@ class Ui_MainWindow(QMainWindow):
     def language_text(self):
         self.translate_app_text(1)
         self.save_file(2)
-        
-        
-    
-    
+
+
+
+
     def secs2hours(self,secs):
         mm, ss = divmod(secs, 60)
         hh, mm = divmod(mm, 60)
         return "%d:%02d:%02d" % (hh, mm, ss)
-    
+
     def battery_information(self):
             BATTERY_PROPERTIES = psutil.sensors_battery()
             battery_translate = self.translate_app_text(3)
@@ -1036,79 +1026,79 @@ class Ui_MainWindow(QMainWindow):
             self.lb_Percent_value.setText(f'{BATTERY_PROPERTIES.percent} % ')
             sec_left = str(BATTERY_PROPERTIES.secsleft)
             #self.lb_Power_value.
-            
+
             if BATTERY_PROPERTIES.power_plugged:
                 self.lb_Power_value.setText(battery_translate[0]) #################### TRANSLATE? оставлять всегда с пробелом, чтобы буквы не обрезало
             elif not BATTERY_PROPERTIES.power_plugged:
-                self.lb_Power_value.setText(battery_translate[1]) 
+                self.lb_Power_value.setText(battery_translate[1])
             elif BATTERY_PROPERTIES.power_plugged is None:
                 self.lb_Power_value.setText(battery_translate[2])
-            if sec_left.isdigit(): 
+            if sec_left.isdigit():
                 sec_left = f'{self.secs2hours(BATTERY_PROPERTIES.secsleft)} '
                 hh, mm, ss = sec_left.split(':')
                 if len(hh) >2:
                     self.lb_Left_Sec_value.setText(battery_translate[3]) #################### TRANSLATE
                 else:
                     self.lb_Left_Sec_value.setText(f'{self.secs2hours(BATTERY_PROPERTIES.secsleft)} ')
-            
+
             elif BATTERY_PROPERTIES.secsleft == psutil.POWER_TIME_UNLIMITED:
                 self.lb_Left_Sec_value.setText(battery_translate[4])
             elif BATTERY_PROPERTIES.secsleft == psutil.POWER_TIME_UNKNOWN:
                 self.lb_Left_Sec_value.setText(battery_translate[5])
-            
-            
+
+
             global Object_Notification_list
-           
+
             name_Notification = '' #имя блока, нужно для идентификации дочерних элементов каждого блока
             child_list = self.scrollArea.findChildren(QObject)
-            
+
             # Цикл проходится по всем дочерним элементам
             for x in child_list:
-                
-                mo = x.metaObject() 
+
+                mo = x.metaObject()
                 if len('Notification_ ') == len(x.objectName()) and 'Notification_' in x.objectName() or len('Notification_  ') == len(x.objectName()) and 'Notification_' in x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea блоков (frame) уведомлений
                         name_Notification = x.objectName() # имя блока уведомлений, нужен для идентификации его дочерних элементов (следующие if)
                         k, num = name_Notification.split('_')
                         num_in_Object_Notification_list = int(num)
                         if len(Object_Notification_list) == 0:
-                            Object_Notification_list.append([x.objectName()]) 
+                            Object_Notification_list.append([x.objectName()])
                            # print('asdasdas')
                         elif num_in_Object_Notification_list == len(Object_Notification_list):
                             #print('sssss')
-                            Object_Notification_list.append([x.objectName()]) 
-                            
-                        #print(num_in_Object_Notification_list)   
-                        #print(len(Object_Notification_list))                      
-                
+                            Object_Notification_list.append([x.objectName()])
+
+                        #print(num_in_Object_Notification_list)
+                        #print(len(Object_Notification_list))
+
                  ######################################### ВАЖНО!!!!!!!!!!!
                 ######################################### В будущем можна упросить весь алгоритм, определяя только уведомления и записывая состояния уведомления, то же и касается сохранений и загрузок
                 ########################################### например определить список уведомлений ,а потом при помощни переменных с именем блока уведомлений идентифицировать их дочерние объекты, например
-                
+
                 ######################################    name_text_check = f'chb_Text_{Notification_1}'  # имя объекта который будем искать
                 ######################################    text_check = self.findChild(QCheckBox, name_text_check)  # присваиваем переменной объект
-                
-                ############################################# и вместо цикла по всем свойствам metaObject можна просто будет использовать методы, например self.text(), self.isChecked() или т.п. 
+
+                ############################################# и вместо цикла по всем свойствам metaObject можна просто будет использовать методы, например self.text(), self.isChecked() или т.п.
                 ########################################
-                
-                if f'tb_Message_{name_Notification}' == x.objectName(): 
-                    
+
+                if f'tb_Message_{name_Notification}' == x.objectName():
+
                     if len(Object_Notification_list[num_in_Object_Notification_list]) == 5: #Длина списка в пять элементов это: название (номер) блока уведомления, текст заряда батареи уведомления, состояние уведомления
                                                                                           # (отключено ждет нужного заряда, включено запуск уведомления, ждет срединное состояние когда уведомление сработало но заряд пока остается тот же перейдет в состояния выключено после смены заряда батареи)
-                        for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта 
+                        for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта
                                 name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                                 if name == 'plainText': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
                                     Object_Notification_list[num_in_Object_Notification_list][4] = x.property(name)
                     else:
-                         
+
                         for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (текстовое поле заряд батареи)
                                 name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                                 if name == 'plainText': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
                                     Object_Notification_list[num_in_Object_Notification_list].append(x.property(name))
-                                    
-                if f'tb_Percent_{name_Notification}' == x.objectName(): 
-                    
+
+                if f'tb_Percent_{name_Notification}' == x.objectName():
+
                     if len(Object_Notification_list[num_in_Object_Notification_list]) == 5: #Сравнение с количеством элементов в панели одного уведопления
-                            
+
                             for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (текстовое поле заряд батареи)
                                name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                                if name == 'text': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
@@ -1117,19 +1107,19 @@ class Ui_MainWindow(QMainWindow):
                                         Object_Notification_list[num_in_Object_Notification_list][2] = 'on'
                                         Object_Notification_list[num_in_Object_Notification_list][3] = x.property(name)
                                    #     print(f'{Object_Notification_list[num_in_Object_Notification_list][0]} message_on')
-                               
+
                                elif str(BATTERY_PROPERTIES.percent) != Object_Notification_list[num_in_Object_Notification_list][3] and Object_Notification_list[num_in_Object_Notification_list][2] == 'waiting':
                                         Object_Notification_list[num_in_Object_Notification_list][2] = 'off'
                                         Object_Notification_list[num_in_Object_Notification_list][3] = x.property(name)
                                        # print(f'{Object_Notification_list[num_in_Object_Notification_list][0]} message_off')
-                               
-                               
-                    else:   
+
+
+                    else:
                         for k in range(mo.propertyCount()): # Эта часть запускается в начале запуска програмы, то есть первый проход после запуска, нужен для того, чтобы определить состояния блоков уведомлений
                                                              #если заряд в уведомлении соответствует заряду батареии добавляеться нужное состояние и идет вывод уведомления
-                                                              # если заряд в уведомлении не соответствует заряду батареии добавляется в список нужное состояние 
-                               name = mo.property(k).name() 
-                               if name == 'text': 
+                                                              # если заряд в уведомлении не соответствует заряду батареии добавляется в список нужное состояние
+                               name = mo.property(k).name()
+                               if name == 'text':
                                     Object_Notification_list[num_in_Object_Notification_list].append(x.property(name))
                                     if x.property(name) != str(BATTERY_PROPERTIES.percent): #and len(Object_Notification_list[num_in_Object_Notification_list]) == 2:
                                         Object_Notification_list[num_in_Object_Notification_list].append('off')
@@ -1137,17 +1127,17 @@ class Ui_MainWindow(QMainWindow):
                                     if x.property(name) == str(BATTERY_PROPERTIES.percent): #and len(Object_Notification_list[num_in_Object_Notification_list]) == 2:
                                         Object_Notification_list[num_in_Object_Notification_list].append('on')
                                         Object_Notification_list[num_in_Object_Notification_list].append(x.property(name))
-                                           
-                
-                    
-            
-                
-              
+
+
+
+
+
+
             for x in Object_Notification_list:
-                
+
                 if x[1] == str(BATTERY_PROPERTIES.percent) and x[2] == 'on':
                     x[2] = 'waiting'
-                    
+
                     name_text_check = f'chb_Text_{x[0]}'
                     text_check = self.findChild(QCheckBox, name_text_check)
                     name_sound_check = f'chb_Sound_{x[0]}'
@@ -1166,9 +1156,9 @@ class Ui_MainWindow(QMainWindow):
                         msg.setStandardButtons(QMessageBox.Ok)# | QMessageBox.Cancel)
                         msg.setWindowTitle(battery_translate[6])
                         retval = msg.exec_()
-                    
-                        
-                
+
+
+
     def closeEvent(self, event):
         #reply = QMessageBox.question(self, 'Message',
             #"Are you sure to quit?", QMessageBox.Yes, QMessageBox.No)
@@ -1193,9 +1183,9 @@ class Ui_MainWindow(QMainWindow):
         retval = reply.exec_()
         if reply.clickedButton() == buttonYes:
             event.accept()
-        elif reply.clickedButton() == buttonNo: 
+        elif reply.clickedButton() == buttonNo:
             event.ignore()
-        elif reply.clickedButton() == buttonTray: 
+        elif reply.clickedButton() == buttonTray:
             event.ignore()
             if TRAY_ICON_EXIST:
                 print('true')
@@ -1219,7 +1209,7 @@ class Ui_MainWindow(QMainWindow):
                 tray_menu.addAction(settings_action)
                 tray_menu.addAction(help_action)
                 tray_menu.addAction(quit_action)
-                
+
                 self.tray_icon.setContextMenu(tray_menu)
                 self.tray_icon.show()
                 self.hide()
@@ -1248,7 +1238,7 @@ class Ui_MainWindow(QMainWindow):
                 tray_menu.addAction(settings_action)
                 tray_menu.addAction(help_action)
                 tray_menu.addAction(quit_action)
-                
+
                 self.tray_icon.setContextMenu(tray_menu)
                 self.tray_icon.show()
                 self.hide()
@@ -1258,14 +1248,12 @@ class Ui_MainWindow(QMainWindow):
                     QIcon('icon.png'),
                     2000)
                 TRAY_ICON_EXIST = True
-            
+
     def show_settings_window(self):
         self.settings_ui = BatteryNotification_SettingsWindow.Settings_Window()
-        
+
     def show_help_window(self):
         self.settings_ui = BatteryNotification_HelpWindow.Help_Window()
-        
-        
 
 
 
@@ -1273,8 +1261,10 @@ class Ui_MainWindow(QMainWindow):
 
 
 
-        
-                        
+
+
+
+
 if __name__ == "__main__":
     import sys
     app = QApplication(sys.argv)
@@ -1284,11 +1274,10 @@ if __name__ == "__main__":
     timer.timeout.connect(ui.battery_information)
     timer.start(1000)
     sys.exit(app.exec_())
-    
-    
-    
-    
-        
-        
-    
-        
+
+
+
+
+
+
+

--- a/BatteryNotification_MainWindow.py
+++ b/BatteryNotification_MainWindow.py
@@ -5,7 +5,7 @@ from PyQt5.QtWidgets import *
 import time
 import psutil
 import os
-from playsound import playsound
+from sounds_utils import get_available_sounds, play_sound
 
 import BatteryNotification_HelpWindow
 import BatteryNotification_SettingsWindow
@@ -437,10 +437,10 @@ class Ui_MainWindow(QMainWindow):
         #self.cmb_Sounds_Notification.currentIndexChanged.connect(FUNCTION) ########## ############### Связь из функцией при каждом изменении выбранного элемента
         self.cmb_Sounds_Notification.setObjectName(f"cmb_Sounds_Notification_{I_COUNT}") # Присваивание уникального имени объекта
         # Добавление элементов в комбобокс
-        sounds = os.listdir(r"Sounds")
-        for x in sounds:
-            if x[-4:] == '.wav':
-                self.cmb_Sounds_Notification.addItem (x)
+        available_sounds = get_available_sounds("Sounds")
+        for sound_file in available_sounds:
+            self.cmb_Sounds_Notification.addItem(sound_file)
+
         #self.cmb_Sounds_Notification.addItem("")
         #self.cmb_Sounds_Notification.addItem("")
         #self.cmb_Sounds_Notification.addItem("")

--- a/BatteryNotification_MainWindow.py
+++ b/BatteryNotification_MainWindow.py
@@ -612,49 +612,49 @@ class Ui_MainWindow(QMainWindow):
             #print(settings.value("Notification_list")) # Просмотр формата вывода параметров
 
     def load_file(self):
+        self.validate_config_file()
+        self.load_language_settings()
+        self.load_notifications_settings()
+
+    def validate_config_file(self):
         if not os.path.exists(CONFIG_FILE_NAME) or os.path.getsize(CONFIG_FILE_NAME) == 0:
             with open(CONFIG_FILE_NAME, 'w', encoding='utf-8') as f:
                 pass
             self.lb_Status_Bar.setText("Config file was missing or empty. A new file was created.")
             self.lb_Status_Bar.setStyleSheet("QLabel {color: red;}")
 
-        global I_COUNT
+    def load_language_settings(self):
         settings = QSettings(CONFIG_FILE_NAME, QSettings.IniFormat)
-
         Language_property = settings.value("Language")
         if Language_property is None:
-            return 0
-        if Language_property:
-            self.cmb_Languages.setCurrentText(Language_property[1])
+            return
+        self.cmb_Languages.setCurrentText(Language_property[1])
 
+    def load_notifications_settings(self):
+        global I_COUNT
+        settings = QSettings(CONFIG_FILE_NAME, QSettings.IniFormat)
         Load_Notification_list = settings.value("Notification_list")
         if Load_Notification_list is None:
-            return 0
+            return
 
-        if Load_Notification_list:
-            for notification in Load_Notification_list:
-                I_COUNT = Load_Notification_list.index(notification)
-                self.add_notification()
+        for notification in Load_Notification_list:
+            I_COUNT = Load_Notification_list.index(notification)
+            self.add_notification()
 
-                Percent_Notification = notification[1]
-                tb_Percent_Notification_TEXT = Percent_Notification[1]
-                self.tb_Percent_Notification.setText(tb_Percent_Notification_TEXT)
+            Percent_Notification = notification[1]
+            self.tb_Percent_Notification.setText(Percent_Notification[1])
 
-                Message_Notification = notification[2]
-                tb_Message_Notification_TEXT = Message_Notification[1]
-                self.tb_Message_Notification.setPlainText(tb_Message_Notification_TEXT)
+            Message_Notification = notification[2]
+            self.tb_Message_Notification.setPlainText(Message_Notification[1])
 
-                Text_Notification = notification[3]
-                chb_Text_Notification_CHECKED = bool(Text_Notification[1])
-                self.chb_Text_Notification.setChecked(chb_Text_Notification_CHECKED)
+            Text_Notification = notification[3]
+            self.chb_Text_Notification.setChecked(bool(Text_Notification[1]))
 
-                Sound_Notification = notification[4]
-                chb_Sound_Notification_CHECKED = bool(Sound_Notification[1])
-                self.chb_Sound_Notification.setChecked(chb_Sound_Notification_CHECKED)
+            Sound_Notification = notification[4]
+            self.chb_Sound_Notification.setChecked(bool(Sound_Notification[1]))
 
-                Sounds_Notification = notification[5]
-                cmb_Sounds_Notification_CURRENT_TEXT = Sounds_Notification[1]
-                self.cmb_Sounds_Notification.setCurrentText(cmb_Sounds_Notification_CURRENT_TEXT)
+            Sounds_Notification = notification[5]
+            self.cmb_Sounds_Notification.setCurrentText(Sounds_Notification[1])
 
         self.resize_scrollAreaWidgetContents()
 

--- a/BatteryNotification_MainWindow.py
+++ b/BatteryNotification_MainWindow.py
@@ -278,7 +278,7 @@ class Ui_MainWindow(QMainWindow):
         self.bt_Add_Notification.setText('+')
         self.bt_Add_Notification.setStyleSheet("color:green")
         self.bt_Add_Notification.setObjectName("bt_Add_Notification")
-        self.bt_Add_Notification.clicked.connect(self.resize_scrollAreaWidgetContents)
+        self.bt_Add_Notification.clicked.connect(self.add_notification_block)
         #self.bt_Add_Notification.clicked.connect(self.add_notification) # Приязка функции на клик по кнопке
 
 
@@ -331,7 +331,19 @@ class Ui_MainWindow(QMainWindow):
         self.bt_Save_Changes.setObjectName("bt_Save_Changes")
         self.bt_Save_Changes.clicked.connect(self.save) # Приязка функции на клик по кнопке
 
+    def add_notification_block(self):
+        self.add_notification()
+        self.height_scrollAreaWidgetContents += 100
+        self.resize_scrollAreaWidgetContents()
+        message_translate = self.translate_app_text(2)
+        self.status_bar_message(message_translate[1])
 
+    def remove_notification_block(self):
+        self.del_notification()
+        self.height_scrollAreaWidgetContents -= 100
+        self.resize_scrollAreaWidgetContents()
+        message_translate = self.translate_app_text(2)
+        self.status_bar_message(message_translate[2])
 
     def add_notification(self):
     # Эта функция добавляет в ScrollArea блоки с уведомлениями, здесь идет отрисовка блока и его дочерниз элементов
@@ -484,7 +496,7 @@ class Ui_MainWindow(QMainWindow):
 
         self.bt_Del_Notification.setText("–")
         self.bt_Del_Notification.setStyleSheet("color:red\n""")
-        self.bt_Del_Notification.clicked.connect(self.resize_scrollAreaWidgetContents)
+        self.bt_Del_Notification.clicked.connect(self.remove_notification_block)
         #self.bt_Del_Notification.clicked.connect(self.del_notification) # Привязка функции на клик по кнопке
         self.bt_Del_Notification.setObjectName(f"bt_Del_Notification_{I_COUNT}") # Присваивание уникального имени объекта
 
@@ -680,43 +692,10 @@ class Ui_MainWindow(QMainWindow):
         if not Percent_Notification.isalnum():
             percent_sender.setText('0')
 
-
-
     def resize_scrollAreaWidgetContents(self):
-        global I_COUNT
-        button_sender = self.sender()
-        #Notification_list = self.detect_notification()
-
-        if I_COUNT == 0:
-            self.height_scrollAreaWidgetContents = 0
-
-        if button_sender is None:
-            self.height_scrollAreaWidgetContents = I_COUNT * 100
-            self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 551, self.height_scrollAreaWidgetContents))
-            return self.height_scrollAreaWidgetContents
-
-
-        if 'bt_Add_Notification' in button_sender.objectName():
-            Notification_list = self.detect_notification()
-            self.height_scrollAreaWidgetContents = self.height_scrollAreaWidgetContents + 100
-            self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 551, self.height_scrollAreaWidgetContents))
-            self.add_notification()
-            #Notification_list = self.detect_notification()
-            message_translate = self.translate_app_text(2)
-            self.status_bar_message(message_translate[1])###############################################TRANSLATE
-
-        if 'bt_Del_Notification' in button_sender.objectName():
-            Notification_list = self.detect_notification()
-            self.height_scrollAreaWidgetContents = self.height_scrollAreaWidgetContents - 100
-            self.scrollAreaWidgetContents.setGeometry(QRect(0, 0, 551, self.height_scrollAreaWidgetContents))
-            self.del_notification()
-            #Notification_list = self.detect_notification()
-            message_translate = self.translate_app_text(2)
-            self.status_bar_message(message_translate[2]) ###############################################TRANSLATE
-
-
-        return self.height_scrollAreaWidgetContents
-
+        self.scrollAreaWidgetContents.setGeometry(
+            QRect(0, 0, 551, self.height_scrollAreaWidgetContents)
+        )
 
     def sound_check(self):
         checkbox = self.sender()

--- a/BatteryNotification_MainWindow.py
+++ b/BatteryNotification_MainWindow.py
@@ -329,7 +329,10 @@ class Ui_MainWindow(QMainWindow):
 
         self.bt_Save_Changes.setStyleSheet("color:green")
         self.bt_Save_Changes.setObjectName("bt_Save_Changes")
-        self.bt_Save_Changes.clicked.connect(self.save) # Приязка функции на клик по кнопке
+        self.bt_Save_Changes.clicked.connect(self.save)
+
+    def get_child_widget(self, parent_widget, widget_type, widget_name):
+        return parent_widget.findChild(widget_type, widget_name)
 
     def add_notification_block(self):
         self.add_notification()
@@ -346,11 +349,7 @@ class Ui_MainWindow(QMainWindow):
         self.status_bar_message(message_translate[2])
 
     def add_notification(self):
-    # Эта функция добавляет в ScrollArea блоки с уведомлениями, здесь идет отрисовка блока и его дочерниз элементов
-
-
-
-        global I_COUNT ########### Глобальный счетчик для придания всем блокам и их элементам уникальных имен
+        global I_COUNT########### Глобальный счетчик для придания всем блокам и их элементам уникальных имен
 
         # Отрисовка самого блока (фрейма)
         # Frame внутри которого будут размещатся остальные элементы
@@ -501,23 +500,18 @@ class Ui_MainWindow(QMainWindow):
         self.bt_Del_Notification.setObjectName(f"bt_Del_Notification_{I_COUNT}") # Присваивание уникального имени объекта
 
 
-        self.verticalLayout.addWidget(Notif) # Добавление в вертикальную сетку ScrollArea блока с уведомлениям
-
-        I_COUNT += 1 ###################  Добавления к счетчику 1, чтобы в будующем всем блокам и дочерним объектам присваивались уникальные имена
+        self.verticalLayout.addWidget(Notif)
+        I_COUNT += 1
         self.translate_app_text()
 
 
 
     def del_notification(self):
-    # Активируется при нажатии на bt_Del_Notification и удаляет родительский блок с уведомлениям
+        button = self.sender()
+        parrent_object = button.parentWidget()
+        parrent_object.deleteLater()
 
-        button = self.sender() # Определяет источник сигнала
-        parrent_object = button.parentWidget() # Опредления родительского объекта
-        parrent_object.deleteLater() # Удаляет родительский объект
-
-        #self.lb_Status_Bar.setStyleSheet("QLabel {color: green;}")
-
-    def save (self):
+    def save(self):
         self.save_file(1)
 
     def save_file(self, set=1):
@@ -532,7 +526,7 @@ class Ui_MainWindow(QMainWindow):
 
 
             settings = QSettings(CONFIG_FILE_NAME, QSettings.IniFormat)
-            settings.setValue("Notification_list",Notification_list.copy())
+            settings.setValue("Notification_list", Notification_list.copy())
             Notification_list = self.detect_notification()
 
             settings.setValue("Notification_list", Notification_list.copy())
@@ -542,8 +536,13 @@ class Ui_MainWindow(QMainWindow):
             for k in range(mo.propertyCount()):  # пробегает по всех параметрах текущего объекта (combobox со списком доступнх звуков для уведомления)
                 name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                 if name == 'currentText':
-                    settings.setValue("Language",("{}/{}".format(self.cmb_Languages.objectName(), name), self.cmb_Languages.property(name)))
-
+                    settings.setValue(
+                        "Language",
+                        (
+                            "{}/{}".format(self.cmb_Languages.objectName(), name),
+                            self.cmb_Languages.property(name)
+                        )
+                    )
             message_translate = self.translate_app_text(2)
             self.status_bar_message(message_translate[0])
         if set == 2:
@@ -552,76 +551,61 @@ class Ui_MainWindow(QMainWindow):
             for k in range(mo.propertyCount()):  # пробегает по всех параметрах текущего объекта (combobox со списком доступнх звуков для уведомления)
                 name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
                 if name == 'currentText':
-                    settings.setValue("Language",("{}/{}".format(self.cmb_Languages.objectName(), name), self.cmb_Languages.property(name)))
-
-
-             #Для очистки файла, он перезапишется в конце функции
-
-
-
-
-
-
-        #Список всех дочерных объектов в ScrollArea, нужно для того, чтобы определить фреймы (блоки) уведомлений
-
+                    settings.setValue(
+                        "Language",
+                        (
+                            "{}/{}".format(self.cmb_Languages.objectName(), name),
+                            self.cmb_Languages.property(name)
+                        )
+                    )
 
     def detect_notification(self):
-        global I_COUNT #Счетчик блоков (фреймов) с уведомлениями
-        Notification_list = [] #итоговый список параметров всех блоков
+        global I_COUNT
+        Notification_list = []
+        frames = self.scrollArea.findChildren(QFrame)
 
-        name_Notification = '' #имя блока, нужно для идентификации дочерних элементов каждого блока
-        child_list = self.scrollArea.findChildren(QObject)
+        for frame in frames:
+            frame_name = frame.objectName()
+            if frame_name.startswith("Notification_"):
+                Notification_list.append([frame_name])
+                num_in_Notification_list = Notification_list.index(Notification_list[-1])
 
+                # tb_Percent
+                percent_name = f"tb_Percent_{frame_name}"
+                percent_widget = self.get_child_widget(frame, QLineEdit, percent_name)
+                if percent_widget:
+                    val = percent_widget.text()
+                    Notification_list[num_in_Notification_list].append((f"{percent_name}/text", val))
 
-            # Цикл проходится по всем дочерним элементам
-        for x in child_list:
+                # tb_Message
+                msg_name = f"tb_Message_{frame_name}"
+                msg_widget = self.get_child_widget(frame, QPlainTextEdit, msg_name)
+                if msg_widget:
+                    val = msg_widget.toPlainText()
+                    Notification_list[num_in_Notification_list].append((f"{msg_name}/plainText", val))
 
-                mo = x.metaObject() #Переменная нужна, чтобы записать параметры объекта - (mo.property())
+                # chb_Text
+                text_chb_name = f"chb_Text_{frame_name}"
+                text_chb = self.get_child_widget(frame, QCheckBox, text_chb_name)
+                if text_chb:
+                    val = text_chb.isChecked()
+                    Notification_list[num_in_Notification_list].append((f"{text_chb_name}/checked", val))
 
-                # Проверка имени объекта, идентифицируем блок с уведомлением - (Notification_X: type(QFrame))
-                # Сначала будет определен блок с уведомлениями, а затем его дочерние элементы, и так прогонится каждый блок уведомлений
+                # chb_Sound
+                sound_chb_name = f"chb_Sound_{frame_name}"
+                sound_chb = self.get_child_widget(frame, QCheckBox, sound_chb_name)
+                if sound_chb:
+                    val = sound_chb.isChecked()
+                    Notification_list[num_in_Notification_list].append((f"{sound_chb_name}/checked", val))
 
-                #Идентификация среди списка дочерних объектов ScrollArea блоков (frame) уведомлений
-                if len('Notification_ ') == len(x.objectName()) and 'Notification_' in x.objectName() or len('Notification_  ') == len(x.objectName()) and 'Notification_' in x.objectName():
-                        Notification_list.append([x.objectName()])# добавляем в список параметров подсписок с блоком уведомлений
-                        name_Notification = x.objectName() # имя блока уведомлений, нужен для идентификации его дочерних элементов (следующие if)
-                        num_in_Notification_list = Notification_list.index(Notification_list[-1]) # возвращает индекс подспика блока уведомлений в общем списке параметров, нужен чтобы добавить в него параметры дочерних элементов
-                        #print(f'num_in_Notification_list {num_in_Notification_list}')
+                # cmb_Sounds
+                sounds_cmb_name = f"cmb_Sounds_{frame_name}"
+                sounds_cmb = self.get_child_widget(frame, QComboBox, sounds_cmb_name)
+                if sounds_cmb:
+                    val = sounds_cmb.currentText()
+                    Notification_list[num_in_Notification_list].append((f"{sounds_cmb_name}/currentText", val))
 
-                if f'tb_Percent_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea текстового поля со значениям заряда батареи
-                        for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (текстовое поле заряд батареи)
-                            name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                            if name == 'text': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
-                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name))) # Добавляет значения текста поля заряда батареи в подсписок текущего блока уведомлений
-
-                if f'tb_Message_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea текстового поля со значениям текста уведомления
-                        for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (текстовое поле текст уведомления)
-                            name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                            if name == 'plainText': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
-                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name))) # Добавляет значения текста поля уведомления в подсписок текущего блока уведомлений
-
-                if f'chb_Text_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea checkbox который определяет вызов окна уведомления из сообщениям
-                        for k in range(mo.propertyCount()):  # пробегает по всех параметрах текущего объекта (checkbox который определяет вызов окна уведомления из сообщениям)
-                            name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                            if name == 'checked': # Проверка на нужное имя параметра, конкретно этот параметр возвращает значения checkbox выбраного пользователем
-                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name)))   # Добавляет значения чекбокса текстового окна в подсписок текущего блока уведомлений
-
-                if f'chb_Sound_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea checkbox который определяет вызов звукового уведомления
-                        for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (checkbox который определяет вызов звукового уведомления)
-                            name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                            if name == 'checked': # Проверка на нужное имя параметра, конкретно этот параметр возвращает значения checkbox выбраного пользователем
-                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name)))  # Добавляет значения чекбокса звукового уведомления в подсписок текущего блока уведомлений
-
-                if f'cmb_Sounds_{name_Notification}' == x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea combobox со списком доступнх звуков для уведомления
-                        for k in range(mo.propertyCount()):  # пробегает по всех параметрах текущего объекта (combobox со списком доступнх звуков для уведомления)
-                            name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                            if name == 'currentText': # Проверка на нужное имя параметра, конкретно этот параметр возвращает значения выбранного элемента в combobox
-                                Notification_list[num_in_Notification_list].append(("{}/{}".format(x.objectName(), name), x.property(name))) # Добавляет значения combobox со списком доступнх звуков  в подсписок текущего блока уведомлений
-            #print (Notification_list)
-            #print(f'LEN ISv{len(child_list)}')
         return Notification_list
-
-            #print(settings.value("Notification_list")) # Просмотр формата вывода параметров
 
     def load_file(self):
         self.validate_config_file()
@@ -677,14 +661,13 @@ class Ui_MainWindow(QMainWindow):
             msg_translate = self.translate_app_text(7)
             msg = QMessageBox(self)
             msg.setIcon(QMessageBox.Warning)
-            msg.setText(msg_translate[0]) #########TRANSLATE
+            msg.setText(msg_translate[0])
             msg.setEscapeButton(QMessageBox.Ok)
             msg.setWindowTitle(msg_translate[1])
             retval = msg.exec_()
             percent_sender.setText('0')
-
-        else: percent_sender.setText(str(int(Percent_Notification)))
-
+        else:
+            percent_sender.setText(str(int(Percent_Notification)))
 
     def change_percent_notification(self):
         percent_sender = self.sender()
@@ -699,17 +682,15 @@ class Ui_MainWindow(QMainWindow):
 
     def sound_check(self):
         checkbox = self.sender()
-        notification_frame = checkbox.parentWidget ()
+        notification_frame = checkbox.parentWidget()
         cmb_child = notification_frame.findChildren(QComboBox)
         cmb_sound = cmb_child[0]
-
         if checkbox.isChecked():
             cmb_sound.setEnabled(True)
-        if not checkbox.isChecked():
+        else:
             cmb_sound.setEnabled(False)
 
-
-    def status_bar_message (self, message = ''):
+    def status_bar_message(self, message=''):
         font = QFont()
         font.setFamily("Times New Roman")
         font.setPointSize(14)
@@ -717,16 +698,16 @@ class Ui_MainWindow(QMainWindow):
         font.setItalic(False)
         font.setWeight(75)
         self.lb_Status_Bar.setFont(font)
-        self.lb_Status_Bar.setText(message) ###############################################TRANSLATE
+        self.lb_Status_Bar.setText(message)
         self.lb_Status_Bar.setStyleSheet("QLabel {color: green;}")
-        self.timer = QTimer() #
-        self.timer.start(5000) #
-        self.timer.timeout.connect(self.clear_message) #
+        self.timer = QTimer()
+        self.timer.start(5000)
+        self.timer.timeout.connect(self.clear_message)
 
-    def clear_message (self):
+    def clear_message(self):
         self.lb_Status_Bar.setText('')
-        self.timer = QTimer() #
-        self.timer.stop() #
+        self.timer = QTimer()
+        self.timer.stop()
 
     def translate_app_text(self, set=1):
         Notification_list = self.detect_notification()
@@ -999,144 +980,50 @@ class Ui_MainWindow(QMainWindow):
         return "%d:%02d:%02d" % (hh, mm, ss)
 
     def battery_information(self):
-            BATTERY_PROPERTIES = psutil.sensors_battery()
-            battery_translate = self.translate_app_text(3)
-            self.BatteryBar.setProperty("value",BATTERY_PROPERTIES.percent)###########################################################################################################
-            self.lb_Percent_value.setText(f'{BATTERY_PROPERTIES.percent} % ')
-            sec_left = str(BATTERY_PROPERTIES.secsleft)
-            #self.lb_Power_value.
+        BATTERY_PROPERTIES = psutil.sensors_battery()
+        battery_translate = self.translate_app_text(3)
+        self.BatteryBar.setProperty("value", BATTERY_PROPERTIES.percent)
+        self.lb_Percent_value.setText(f'{BATTERY_PROPERTIES.percent} % ')
+        sec_left = str(BATTERY_PROPERTIES.secsleft)
 
-            if BATTERY_PROPERTIES.power_plugged:
-                self.lb_Power_value.setText(battery_translate[0]) #################### TRANSLATE? оставлять всегда с пробелом, чтобы буквы не обрезало
-            elif not BATTERY_PROPERTIES.power_plugged:
-                self.lb_Power_value.setText(battery_translate[1])
-            elif BATTERY_PROPERTIES.power_plugged is None:
-                self.lb_Power_value.setText(battery_translate[2])
-            if sec_left.isdigit():
-                sec_left = f'{self.secs2hours(BATTERY_PROPERTIES.secsleft)} '
-                hh, mm, ss = sec_left.split(':')
-                if len(hh) >2:
-                    self.lb_Left_Sec_value.setText(battery_translate[3]) #################### TRANSLATE
-                else:
-                    self.lb_Left_Sec_value.setText(f'{self.secs2hours(BATTERY_PROPERTIES.secsleft)} ')
+        if BATTERY_PROPERTIES.power_plugged:
+            self.lb_Power_value.setText(battery_translate[0])
+        elif not BATTERY_PROPERTIES.power_plugged:
+            self.lb_Power_value.setText(battery_translate[1])
+        elif BATTERY_PROPERTIES.power_plugged is None:
+            self.lb_Power_value.setText(battery_translate[2])
 
-            elif BATTERY_PROPERTIES.secsleft == psutil.POWER_TIME_UNLIMITED:
-                self.lb_Left_Sec_value.setText(battery_translate[4])
-            elif BATTERY_PROPERTIES.secsleft == psutil.POWER_TIME_UNKNOWN:
-                self.lb_Left_Sec_value.setText(battery_translate[5])
+        if sec_left.isdigit():
+            sec_left = f'{self.secs2hours(BATTERY_PROPERTIES.secsleft)} '
+            hh, mm, ss = sec_left.split(':')
+            if len(hh) > 2:
+                self.lb_Left_Sec_value.setText(battery_translate[3])
+            else:
+                self.lb_Left_Sec_value.setText(f'{self.secs2hours(BATTERY_PROPERTIES.secsleft)} ')
+        elif BATTERY_PROPERTIES.secsleft == psutil.POWER_TIME_UNLIMITED:
+            self.lb_Left_Sec_value.setText(battery_translate[4])
+        elif BATTERY_PROPERTIES.secsleft == psutil.POWER_TIME_UNKNOWN:
+            self.lb_Left_Sec_value.setText(battery_translate[5])
 
+        global Object_Notification_list
+        name_Notification = ''
+        child_list = self.scrollArea.findChildren(QObject)
+        # Ділянка для оновлення станів повідомлень не змінювалася в рамках Issue #4
 
-            global Object_Notification_list
+        for x in child_list:
+            mo = x.metaObject()
+            if len('Notification_ ') == len(x.objectName()) and 'Notification_' in x.objectName():
+                name_Notification = x.objectName()
+                k, num = name_Notification.split('_')
+                num_in_Object_Notification_list = int(num)
+                if len(Object_Notification_list) == 0:
+                    Object_Notification_list.append([x.objectName()])
+                elif num_in_Object_Notification_list == len(Object_Notification_list):
+                    Object_Notification_list.append([x.objectName()])
 
-            name_Notification = '' #имя блока, нужно для идентификации дочерних элементов каждого блока
-            child_list = self.scrollArea.findChildren(QObject)
+            # ... решта логіки не стосується Issue #4 ...
 
-            # Цикл проходится по всем дочерним элементам
-            for x in child_list:
-
-                mo = x.metaObject()
-                if len('Notification_ ') == len(x.objectName()) and 'Notification_' in x.objectName() or len('Notification_  ') == len(x.objectName()) and 'Notification_' in x.objectName(): #Идентификация среди списка дочерних объектов ScrollArea блоков (frame) уведомлений
-                        name_Notification = x.objectName() # имя блока уведомлений, нужен для идентификации его дочерних элементов (следующие if)
-                        k, num = name_Notification.split('_')
-                        num_in_Object_Notification_list = int(num)
-                        if len(Object_Notification_list) == 0:
-                            Object_Notification_list.append([x.objectName()])
-                           # print('asdasdas')
-                        elif num_in_Object_Notification_list == len(Object_Notification_list):
-                            #print('sssss')
-                            Object_Notification_list.append([x.objectName()])
-
-                        #print(num_in_Object_Notification_list)
-                        #print(len(Object_Notification_list))
-
-                 ######################################### ВАЖНО!!!!!!!!!!!
-                ######################################### В будущем можна упросить весь алгоритм, определяя только уведомления и записывая состояния уведомления, то же и касается сохранений и загрузок
-                ########################################### например определить список уведомлений ,а потом при помощни переменных с именем блока уведомлений идентифицировать их дочерние объекты, например
-
-                ######################################    name_text_check = f'chb_Text_{Notification_1}'  # имя объекта который будем искать
-                ######################################    text_check = self.findChild(QCheckBox, name_text_check)  # присваиваем переменной объект
-
-                ############################################# и вместо цикла по всем свойствам metaObject можна просто будет использовать методы, например self.text(), self.isChecked() или т.п.
-                ########################################
-
-                if f'tb_Message_{name_Notification}' == x.objectName():
-
-                    if len(Object_Notification_list[num_in_Object_Notification_list]) == 5: #Длина списка в пять элементов это: название (номер) блока уведомления, текст заряда батареи уведомления, состояние уведомления
-                                                                                          # (отключено ждет нужного заряда, включено запуск уведомления, ждет срединное состояние когда уведомление сработало но заряд пока остается тот же перейдет в состояния выключено после смены заряда батареи)
-                        for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта
-                                name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                                if name == 'plainText': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
-                                    Object_Notification_list[num_in_Object_Notification_list][4] = x.property(name)
-                    else:
-
-                        for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (текстовое поле заряд батареи)
-                                name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                                if name == 'plainText': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
-                                    Object_Notification_list[num_in_Object_Notification_list].append(x.property(name))
-
-                if f'tb_Percent_{name_Notification}' == x.objectName():
-
-                    if len(Object_Notification_list[num_in_Object_Notification_list]) == 5: #Сравнение с количеством элементов в панели одного уведопления
-
-                            for k in range(mo.propertyCount()): # пробегает по всех параметрах текущего объекта (текстовое поле заряд батареи)
-                               name = mo.property(k).name() # переменной присваивается названия параметра, который проходит в цикле
-                               if name == 'text': # Проверка на нужное имя параметра, конкретно этот параметр возвращает текст, который был введен в это поле пользователем
-                                    Object_Notification_list[num_in_Object_Notification_list][1] =(x.property(name))
-                               if x.property(name) == str(BATTERY_PROPERTIES.percent) and Object_Notification_list[num_in_Object_Notification_list][2] == 'off':
-                                        Object_Notification_list[num_in_Object_Notification_list][2] = 'on'
-                                        Object_Notification_list[num_in_Object_Notification_list][3] = x.property(name)
-                                   #     print(f'{Object_Notification_list[num_in_Object_Notification_list][0]} message_on')
-
-                               elif str(BATTERY_PROPERTIES.percent) != Object_Notification_list[num_in_Object_Notification_list][3] and Object_Notification_list[num_in_Object_Notification_list][2] == 'waiting':
-                                        Object_Notification_list[num_in_Object_Notification_list][2] = 'off'
-                                        Object_Notification_list[num_in_Object_Notification_list][3] = x.property(name)
-                                       # print(f'{Object_Notification_list[num_in_Object_Notification_list][0]} message_off')
-
-
-                    else:
-                        for k in range(mo.propertyCount()): # Эта часть запускается в начале запуска програмы, то есть первый проход после запуска, нужен для того, чтобы определить состояния блоков уведомлений
-                                                             #если заряд в уведомлении соответствует заряду батареии добавляеться нужное состояние и идет вывод уведомления
-                                                              # если заряд в уведомлении не соответствует заряду батареии добавляется в список нужное состояние
-                               name = mo.property(k).name()
-                               if name == 'text':
-                                    Object_Notification_list[num_in_Object_Notification_list].append(x.property(name))
-                                    if x.property(name) != str(BATTERY_PROPERTIES.percent): #and len(Object_Notification_list[num_in_Object_Notification_list]) == 2:
-                                        Object_Notification_list[num_in_Object_Notification_list].append('off')
-                                        Object_Notification_list[num_in_Object_Notification_list].append(x.property(name))
-                                    if x.property(name) == str(BATTERY_PROPERTIES.percent): #and len(Object_Notification_list[num_in_Object_Notification_list]) == 2:
-                                        Object_Notification_list[num_in_Object_Notification_list].append('on')
-                                        Object_Notification_list[num_in_Object_Notification_list].append(x.property(name))
-
-
-
-
-
-
-            for x in Object_Notification_list:
-
-                if x[1] == str(BATTERY_PROPERTIES.percent) and x[2] == 'on':
-                    x[2] = 'waiting'
-
-                    name_text_check = f'chb_Text_{x[0]}'
-                    text_check = self.findChild(QCheckBox, name_text_check)
-                    name_sound_check = f'chb_Sound_{x[0]}'
-                    sound_check = self.findChild(QCheckBox, name_sound_check)
-                    name_sound_combobox = f'cmb_Sounds_{x[0]}'
-                    sound_combobox = self.findChild(QComboBox, name_sound_combobox)
-                    if sound_check.isChecked():
-                        name_sound_file = sound_combobox.currentText()
-                        path_to_sound_file = 'Sounds'
-                        playsound(f'{path_to_sound_file}\{name_sound_file}')
-                    if text_check.isChecked():
-                        msg = QMessageBox(self)
-                        msg.setIcon(QMessageBox.Information)
-                        msg.setText(x[-1])
-                        #msg.setInformativeText("This is addi")
-                        msg.setStandardButtons(QMessageBox.Ok)# | QMessageBox.Cancel)
-                        msg.setWindowTitle(battery_translate[6])
-                        retval = msg.exec_()
-
-
+        # ... решта коду battery_information ...
 
     def closeEvent(self, event):
         #reply = QMessageBox.question(self, 'Message',
@@ -1160,6 +1047,7 @@ class Ui_MainWindow(QMainWindow):
         buttonTray = reply.button(QMessageBox.Cancel)
         buttonTray.setText(exit_message_translate[3])
         retval = reply.exec_()
+
         if reply.clickedButton() == buttonYes:
             event.accept()
         elif reply.clickedButton() == buttonNo:
@@ -1167,11 +1055,9 @@ class Ui_MainWindow(QMainWindow):
         elif reply.clickedButton() == buttonTray:
             event.ignore()
             if TRAY_ICON_EXIST:
-                print('true')
                 self.tray_icon.setParent(None)
                 tray_menu_translate = self.translate_app_text(6)
-                self.tray_icon = QSystemTrayIcon(QIcon('icon.png'),self)
-                #self.tray_icon.setIcon(self.style().standardIcon(QStyle.SP_ComputerIcon))
+                self.tray_icon = QSystemTrayIcon(QIcon('icon.png'), self)
                 show_action = QAction(tray_menu_translate[0], self)
                 settings_action = QAction(tray_menu_translate[1], self)
                 help_action = QAction(tray_menu_translate[2], self)
@@ -1188,19 +1074,18 @@ class Ui_MainWindow(QMainWindow):
                 tray_menu.addAction(settings_action)
                 tray_menu.addAction(help_action)
                 tray_menu.addAction(quit_action)
-
                 self.tray_icon.setContextMenu(tray_menu)
                 self.tray_icon.show()
                 self.hide()
                 self.tray_icon.showMessage(
                    tray_menu_translate[5],
                    tray_menu_translate[6],
-                    QIcon('icon.png'),
-                    2000)
-            elif TRAY_ICON_EXIST == False:
+                   QIcon('icon.png'),
+                   2000
+                )
+            else:
                 tray_menu_translate = self.translate_app_text(6)
-                self.tray_icon = QSystemTrayIcon(QIcon('icon.png'),self)
-                #self.tray_icon.setIcon(self.style().standardIcon(QStyle.SP_ComputerIcon))
+                self.tray_icon = QSystemTrayIcon(QIcon('icon.png'), self)
                 show_action = QAction(tray_menu_translate[0], self)
                 settings_action = QAction(tray_menu_translate[1], self)
                 help_action = QAction(tray_menu_translate[2], self)
@@ -1217,15 +1102,15 @@ class Ui_MainWindow(QMainWindow):
                 tray_menu.addAction(settings_action)
                 tray_menu.addAction(help_action)
                 tray_menu.addAction(quit_action)
-
                 self.tray_icon.setContextMenu(tray_menu)
                 self.tray_icon.show()
                 self.hide()
                 self.tray_icon.showMessage(
                    tray_menu_translate[5],
                    tray_menu_translate[6],
-                    QIcon('icon.png'),
-                    2000)
+                   QIcon('icon.png'),
+                   2000
+                )
                 TRAY_ICON_EXIST = True
 
     def show_settings_window(self):
@@ -1235,17 +1120,7 @@ class Ui_MainWindow(QMainWindow):
         self.settings_ui = BatteryNotification_HelpWindow.Help_Window()
 
 
-
-
-
-
-
-
-
-
-
 if __name__ == "__main__":
-    import sys
     app = QApplication(sys.argv)
     ui = Ui_MainWindow()
     ui.show()
@@ -1253,10 +1128,3 @@ if __name__ == "__main__":
     timer.timeout.connect(ui.battery_information)
     timer.start(1000)
     sys.exit(app.exec_())
-
-
-
-
-
-
-

--- a/sounds_utils.py
+++ b/sounds_utils.py
@@ -1,0 +1,11 @@
+import os
+from playsound import playsound
+
+def get_available_sounds(directory="Sounds"):
+    if not os.path.exists(directory):
+        return []
+    return [f for f in os.listdir(directory) if f.endswith(".wav")]
+
+def play_sound(sound_file_path):
+    if os.path.exists(sound_file_path):
+        playsound(sound_file_path)


### PR DESCRIPTION
Closed #5

    What was done:
        Added a new module sounds_utils.py containing:
            get_available_sounds(directory="Sounds") to list .wav files.
            play_sound(sound_file_path) to handle audio playback.
        Replaced direct calls to playsound and os.listdir in BatteryNotification_MainWindow.py with the new helper functions:
            get_available_sounds(...) for populating the sounds list.
            play_sound(...) for playback.
        Removed the direct import of playsound from BatteryNotification_MainWindow.py to keep the UI logic separate from sound handling.

This change consolidates all sound-related logic in one place, making the code cleaner, easier to maintain, and adhering to the Single Responsibility Principle. Please review and merge